### PR TITLE
Bugfix: Add default values for Job-attributes

### DIFF
--- a/rq_mantis/app.py
+++ b/rq_mantis/app.py
@@ -122,9 +122,9 @@ def queue_detail(name):
     for job_id in rq.registry.StartedJobRegistry(name).get_job_ids():
         job = Job.fetch(job_id)
         try:
-            cleaned_func_name = job.func_name
-            cleaned_args = job.cleaned_args
-            cleaned_kwargs = job.cleaned_kwargs
+            cleaned_func_name = getattr(job, 'func_name', 'No function name')
+            cleaned_args = getattr(job, 'cleaned_args', 'No cleaned args')
+            cleaned_kwargs = getattr(job, 'cleaned_kwargs', 'No cleaned kwargs')
         except UnpickleError:
             cleaned_func_name = 'UnpickleError'
             cleaned_args = 'UnpickleError'

--- a/rq_mantis/app.py
+++ b/rq_mantis/app.py
@@ -122,9 +122,9 @@ def queue_detail(name):
     for job_id in rq.registry.StartedJobRegistry(name).get_job_ids():
         job = Job.fetch(job_id)
         try:
-            cleaned_func_name = getattr(job, 'func_name', 'No function name')
-            cleaned_args = getattr(job, 'cleaned_args', 'No cleaned args')
-            cleaned_kwargs = getattr(job, 'cleaned_kwargs', 'No cleaned kwargs')
+            cleaned_func_name = job.func_name
+            cleaned_args = getattr(job, 'cleaned_args', [])
+            cleaned_kwargs = getattr(job, 'cleaned_kwargs', {})
         except UnpickleError:
             cleaned_func_name = 'UnpickleError'
             cleaned_args = 'UnpickleError'


### PR DESCRIPTION
The Job-object does not always have a `cleaned_args`-attribute, which results in a 500-error when trying to access the job list (`/queue/<name>`) of a queue that has a job without this attribute:

This is the stacktrace from the machine running the dashboard:
```
[2021-08-23 15:48:23,067] ERROR in app: Exception on /queue/import_jobs [GET]
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/dist-packages/rq_mantis/app.py", line 126, in queue_detail
    cleaned_args = job.cleaned_args
AttributeError: 'Job' object has no attribute 'cleaned_args'
127.0.0.1 - - [23/Aug/2021 15:48:23] "GET /queue/import_jobs HTTP/1.0" 500 -
```

We should check if the job has the attribute we would like to access, and fallback to some default value if it does not.